### PR TITLE
Updated url for Dashboard Notification to point to github.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "externals"]
 	path = externals
-	url = git@bitbucket.org:incsub/wpmudev-dashboard-notification.git
+	url = git@github.com:wpmudev/wpmudev-dashboard-notification.git
 	branch = master


### PR DESCRIPTION
Updated submodule url from git@bitbucket.org:incsub/wpmudev-dashboard-notification.git  to git@github.com:wpmudev/wpmudev-dashboard-notification.git